### PR TITLE
Dev/close handles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 sysinfo = "0.28"
-pe-util = { version = "0.1.0" , git = "https://github.com/Nordgaren/pe-util.git" }
+pe-util = { git = "https://github.com/Nordgaren/pe-util.git" }
 clap = { version = "4.4.16", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ into Ghidra for analysis.
 ### Dumping memory
 You'll want to invoke memory_mirror like so:
 ```shell
-$ ./memory_mirror.exe -p <output directory> pid <pid> 
+$ ./memory_mirror.exe pid <pid> -p <output directory>  
 ```
 or
 ```shell
-$ ./memory_mirror.exe -p <output directory> name some_program.exe
+$ ./memory_mirror.exe name some_program.exe -p <output directory>  
 ```
 
 This will write dumped memory to `<output directory>`.

--- a/src/args.rs
+++ b/src/args.rs
@@ -8,7 +8,7 @@ pub struct Args {
     pub(crate) command: DumpType,
 
     /// Output folder.
-    #[arg(short, long, default_value = "")]
+    #[arg(short, long, global = true,default_value = "")]
     pub(crate) path: String,
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -8,7 +8,7 @@ pub struct Args {
     pub(crate) command: DumpType,
 
     /// Output folder.
-    #[arg(short, long, global = true,default_value = "")]
+    #[arg(short, long, global = true, default_value = "")]
     pub(crate) path: String,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ fn dump_buffer(path: &str, buffer: Vec<u8>) {
 }
 
 unsafe fn patch_section_headers(mut buffer: Vec<u8>) -> Vec<u8> {
-    let pe = match PE::from_slice(&buffer[..]) {
+    let mut pe = match PE::from_slice(&buffer[..]) {
         Ok(p) => p,
         Err(_) => {
             println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use pe_util::PE;
 use std::fs;
 use std::fs::File;
 use std::io::Write;
-use std::ops::Range;
+use std::ops::{Range, Sub};
 mod args;
 mod process;
 mod windows;
@@ -71,7 +71,7 @@ unsafe fn dump(path: &str, pid: u32) {
         .filter(|m| {
             !modules
                 .iter()
-                .any(|module| module.range.contains(&m.range.end))
+                .any(|module| module.range.contains(&m.range.end.sub(1)))
         })
         .collect::<Vec<MemoryRegion>>();
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -51,7 +51,10 @@ pub(crate) fn open_process(process: u32) -> std::io::Result<usize> {
 
         if process_id == INVALID_HANDLE_VALUE {
             let last_error = GetLastError();
-            return Err(Error::new(ErrorKind::AddrInUse, format!("Could not open process {process}. Invalid handle: {process_id}. LastError: 0x{last_error:X}")));
+            return Err(Error::new(
+                ErrorKind::AddrInUse,
+                format!("Could not open process {process}. Invalid handle: {process_id}. LastError: 0x{last_error:X}"),
+            ));
         }
 
         Ok(process_id)

--- a/src/process.rs
+++ b/src/process.rs
@@ -5,10 +5,7 @@ use std::io::{Error, ErrorKind};
 use std::mem::size_of;
 use std::ops::Range;
 
-use crate::windows::api::{
-    CreateToolhelp32Snapshot, GetLastError, Module32First, Module32Next, OpenProcess, OpenThread,
-    ReadProcessMemory, ResumeThread, SuspendThread, Thread32First, Thread32Next, VirtualQueryEx,
-};
+use crate::windows::api::{CloseHandle, CreateToolhelp32Snapshot, GetLastError, GetThreadContext, Module32First, Module32Next, OpenProcess, OpenThread, ReadProcessMemory, ResumeThread, SuspendThread, Thread32First, Thread32Next, VirtualQueryEx};
 use crate::windows::consts::{
     INVALID_HANDLE_VALUE, MEM_FREE, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ, TH32CS_SNAPMODULE,
     TH32CS_SNAPTHREAD, THREAD_SUSPEND_RESUME,
@@ -67,7 +64,10 @@ pub(crate) fn open_thread(access: u32, inherit: bool, thread: u32) -> std::io::R
 
         if thread_id == 0 {
             let last_error = GetLastError();
-            return Err(Error::new(ErrorKind::AddrInUse, format!("Could not open process {thread}. Invalid handle: {thread_id}. LastError: 0x{last_error:X}")));
+            return Err(Error::new(
+                ErrorKind::AddrInUse,
+                format!("Could not open process {thread}. Invalid handle: {thread_id}. LastError: 0x{last_error:X}"),
+            ));
         }
 
         Ok(thread_id)
@@ -81,7 +81,10 @@ pub(crate) fn snapshot_process(process: u32) -> std::io::Result<usize> {
 
         if snapshot_handle == INVALID_HANDLE_VALUE {
             let last_error = GetLastError();
-            return Err(Error::new(ErrorKind::AddrInUse, format!("Could not open snapshot for process {process}. Invalid handle: {snapshot_handle}. LastError: 0x{last_error:X}")));
+            return Err(Error::new(
+                ErrorKind::AddrInUse,
+                format!("Could not open snapshot for process {process}. Invalid handle: {snapshot_handle}. LastError: 0x{last_error:X}"),
+            ));
         }
 
         Ok(snapshot_handle)
@@ -115,8 +118,9 @@ pub(crate) unsafe fn freeze_process(snapshot: usize, process: u32) -> Vec<usize>
 }
 
 pub(crate) unsafe fn resume_threads(threads: Vec<usize>) {
-    for thread in threads.iter() {
-        ResumeThread(*thread);
+    for thread in threads.into_iter() {
+        ResumeThread(thread);
+        CloseHandle(thread);
     }
 }
 
@@ -129,14 +133,18 @@ pub(crate) unsafe fn enumerate_modules(process: usize, snapshot: usize) -> Vec<P
 
     let mut results = vec![];
     loop {
-        let module_name = CStr::from_bytes_until_nul(&current_entry.szModule)
+        let mut name = CStr::from_bytes_until_nul(&current_entry.szModule)
             .unwrap()
             .to_str()
             .unwrap()
             .to_string();
 
+        if name.is_empty() {
+            name.push_str("UNK-MODULE")
+        }
+
         let mut process_module = ProcessModule {
-            name: module_name,
+            name,
             range: Range {
                 start: current_entry.hModule,
                 end: current_entry.hModule + current_entry.dwSize as usize,

--- a/src/process.rs
+++ b/src/process.rs
@@ -5,7 +5,7 @@ use std::io::{Error, ErrorKind};
 use std::mem::size_of;
 use std::ops::Range;
 
-use crate::windows::api::{CloseHandle, CreateToolhelp32Snapshot, GetLastError, GetThreadContext, Module32First, Module32Next, OpenProcess, OpenThread, ReadProcessMemory, ResumeThread, SuspendThread, Thread32First, Thread32Next, VirtualQueryEx};
+use crate::windows::api::{CloseHandle, CreateToolhelp32Snapshot, GetLastError, Module32First, Module32Next, OpenProcess, OpenThread, ReadProcessMemory, ResumeThread, SuspendThread, Thread32First, Thread32Next, VirtualQueryEx};
 use crate::windows::consts::{
     INVALID_HANDLE_VALUE, MEM_FREE, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ, TH32CS_SNAPMODULE,
     TH32CS_SNAPTHREAD, THREAD_SUSPEND_RESUME,

--- a/src/windows/api.rs
+++ b/src/windows/api.rs
@@ -6,6 +6,7 @@ use std::ffi::c_void;
 #[link(name = "kernel32", kind = "raw-dylib")]
 extern "system" {
     pub fn CreateToolhelp32Snapshot(dwFlags: u32, th32ProcessID: u32) -> usize;
+    pub fn CloseHandle(hObject: usize) -> bool;
     pub fn GetLastError() -> u32;
     pub fn Module32First(hSnapshot: usize, lpee: *mut MODULEENTRY32) -> bool;
     pub fn Module32Next(hSnapshot: usize, lpee: *mut MODULEENTRY32) -> bool;


### PR DESCRIPTION
Added CloseHandle method and closed handles when we unfreeze the threads.

Also fixed positional argument of path only being allowed in front. Now it can be anywhere.

Fixed something that needed to be mutable for pe-util, as well as made better naming and added `UNK-MODULE` as name for any modules with an empty name, to make them stand out.

Fixed format of some errors so they aren't just one long ass line (Thats Rust Format for not doing this for me).


